### PR TITLE
Specify number of bcryptRounds on model (fixes #3)

### DIFF
--- a/lib/secure-password.js
+++ b/lib/secure-password.js
@@ -35,12 +35,27 @@ function enableSecurePasswordPlugin (Bookshelf) {
   }
 
   /**
+   * Get the number of bcrypt salt rounds from the model.  defaults to `DEFAULT_SALT_ROUNDS`
+   *
+   * @param {Model} model - the Bookshelf model
+   * @returns {Number} - The number of bcrypt salt rounds
+   */
+  function bcryptRounds (model) {
+    if (typeof model.bcryptRounds === 'number' && model.bcryptRounds === parseInt(model.bcryptRounds, 10)) {
+      return model.bcryptRounds
+    }
+
+    return DEFAULT_SALT_ROUNDS
+  }
+
+  /**
    * Generate the BCrypt hash for a given string.
    *
+   * @param {Number} rounds - The number of bcrypt salt rounds
    * @param {String} value - The string to hash
    * @returns {Promise.<String>} - A BCrypt hashed version of the string
    */
-  function hash (value) {
+  function hash (rounds, value) {
     if (value === null) {
       return Promise.resolve(null)
     }
@@ -50,7 +65,7 @@ function enableSecurePasswordPlugin (Bookshelf) {
     }
 
     return bcrypt
-      .genSalt(DEFAULT_SALT_ROUNDS)
+      .genSalt(rounds)
       .then((salt) => {
         return bcrypt.hash(value, salt)
       })
@@ -90,7 +105,7 @@ function enableSecurePasswordPlugin (Bookshelf) {
     model.on('saving', (model) => {
       let value = model[PRIVATE_PASSWORD_FIELD]
 
-      return hash(value).then((_hashed) => {
+      return hash(bcryptRounds(model), value).then((_hashed) => {
         model.unset(DEFAULT_PASSWORD_FIELD)
         if (_hashed !== undefined) {
           model.set(field, _hashed)

--- a/test/secure-password.spec.js
+++ b/test/secure-password.spec.js
@@ -13,6 +13,7 @@ describe('bookshelf-secure-password', function () {
   let model
   let BasicModel
   let CustomModel
+  let RoundsModel
 
   before(function () {
     knex = new Knex({ client: 'pg' })
@@ -27,6 +28,11 @@ describe('bookshelf-secure-password', function () {
 
     CustomModel = bookshelf.Model.extend({
       hasSecurePassword: 'custom_column'
+    })
+
+    RoundsModel = bookshelf.Model.extend({
+      hasSecurePassword: true,
+      bcryptRounds: 5
     })
   })
 
@@ -129,6 +135,30 @@ describe('bookshelf-secure-password', function () {
 
         expect(model.get('custom_column')).to.be.a.string
         expect(model.attributes.custom_column).to.be.a.string
+      })
+    })
+
+    describe('with a bcrypt rounds', function () {
+      describe('custom number of rounds', function () {
+        before(function () {
+          model = new RoundsModel({ id: 3, password: 'testing' })
+          return model.save()
+        })
+
+        it('uses custom bcrypt rounds', function () {
+          expect(model.get('password_digest').substr(4, 2)).to.equal('05')
+        })
+      })
+
+      describe('default number of rounds', function () {
+        before(function () {
+          model = new BasicModel({ id: 4, password: 'testing' })
+          return model.save()
+        })
+
+        it('uses default bcrypt rounds', function () {
+          expect(model.get('password_digest').substr(4, 2)).to.equal('12')
+        })
       })
     })
   })


### PR DESCRIPTION
For #3. Tests the resulting hash for number of bcrypt rounds. Open to changes in naming conventions!