### PR TITLE
Add one step authentication method to Model class

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ npm install bookshelf-secure-password --save
   })
   ```
 
+4.1. Optionaly you can use the one step authentication method `login` on the Model class to retrieve an authenticated model.
+
+  ```javascript
+  User.login({email: 'user@example.org'}, 'testing')
+      .then((usr) => console.log(`Auth as ${usr.get('name').}`))
+      .catch((err) => console.error(err.message) )
+  ```
+
 ## Example
 
 ```javascript
@@ -104,11 +112,7 @@ function signUp (email, password) {
  * @returns {Promise.<User>} A promise resolving to the authenticated User, or rejected with a `PasswordMismatchError`.
  */
 function signIn (email, password) {
-  return User.forge({ email: email })
-    .fetch()
-    .then(function (user) {
-      return user.authenticate(password)
-    })
+  return User.login({ email: email }, password)
 }
 ```
 

--- a/lib/secure-password.js
+++ b/lib/secure-password.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const Promise = require('bluebird')
+const {inspect} = require('util')
+
 function enableSecurePasswordPlugin (Bookshelf) {
   const DEFAULT_PASSWORD_FIELD = 'password'
   const PRIVATE_PASSWORD_FIELD = '__password'
@@ -140,7 +143,28 @@ function enableSecurePasswordPlugin (Bookshelf) {
           return this
         })
     }
+  },
+  /*** Class methods ***/
+  {
+    login: Promise.method(function(query, password) {
+      if (!this.prototype.hasSecurePassword) {
+        throw Error("It's not a secure password enabled model.");
+      }
+      const table = this.prototype.tableName
+      const Model = this
+      return this.forge(query)
+        .fetch()
+        .then(function (model) {
+          if (!model) {
+            let message = `Can't find ${inspect(query).replace(/^..(.*)..$/,'$1')} in ${table}.`
+            throw new Model.PasswordMismatchError(message)
+          }
+          return model.authenticate(password)
+        })
+    })
   })
+
+  Model.__mkHash = hash // make it testable
 
   Bookshelf.Model = Model
 }

--- a/lib/secure-password.js
+++ b/lib/secure-password.js
@@ -143,12 +143,11 @@ function enableSecurePasswordPlugin (Bookshelf) {
           return this
         })
     }
-  },
-  /*** Class methods ***/
-  {
-    login: Promise.method(function(query, password) {
+  }, {
+  /* * * Class methods * * */
+    login: Promise.method(function (query, password) {
       if (!this.prototype.hasSecurePassword) {
-        throw Error("It's not a secure password enabled model.");
+        throw Error("It's not a secure password enabled model.")
       }
       const table = this.prototype.tableName
       const Model = this
@@ -156,7 +155,7 @@ function enableSecurePasswordPlugin (Bookshelf) {
         .fetch()
         .then(function (model) {
           if (!model) {
-            let message = `Can't find ${inspect(query).replace(/^..(.*)..$/,'$1')} in ${table}.`
+            let message = `Can't find ${inspect(query).replace(/^..(.*)..$/, '$1')} in ${table}.`
             throw new Model.PasswordMismatchError(message)
           }
           return model.authenticate(password)

--- a/test/secure-password.spec.js
+++ b/test/secure-password.spec.js
@@ -13,21 +13,32 @@ describe('bookshelf-secure-password', function () {
   let model
   let BasicModel
   let CustomModel
+  let expectedQueryResponse
 
   before(function () {
     knex = new Knex({ client: 'pg' })
     mockKnex.mock(knex)
+    let tracker = mockKnex.getTracker()
+    tracker.install()
+    tracker.on('query', (query)=> query.response(expectedQueryResponse) )
 
     bookshelf = new Bookshelf(knex)
     bookshelf.plugin(securePassword)
 
     BasicModel = bookshelf.Model.extend({
+      tableName: 'some_table',
       hasSecurePassword: true
     })
 
     CustomModel = bookshelf.Model.extend({
+      tableName: 'other_table',
       hasSecurePassword: 'custom_column'
     })
+
+  })
+
+  beforeEach(function () {
+    expectedQueryResponse = []
   })
 
   after(function () {
@@ -176,7 +187,7 @@ describe('bookshelf-secure-password', function () {
 
         it('rejects with a PasswordMismatchError if the no password is provided', function () {
           return model.authenticate().then((model) => {
-            expect(model).to.be.defined
+            expect(false).to.be.true
           }, (err) => {
             expect(err).to.be.defined
             expect(err).to.be.an.instanceof(PasswordMismatchError)
@@ -197,6 +208,110 @@ describe('bookshelf-secure-password', function () {
           expect(err).to.be.defined
           expect(err).to.be.an.instanceof(TypeError)
         }
+      })
+    })
+  })
+  describe('One step model authenticate', function () {
+    describe('with hasSecurePassword enabled on the model', function () {
+      beforeEach(function () {
+        model = new BasicModel({ id: 1, email: 'user@example.org', password: 'testing' })
+      })
+      describe('before save', function () {
+        it('does not authenticate until a saved record match', function () {
+          return BasicModel.login({email: 'user@example.org'}, 'testing').then(
+          (model) => {
+            throw Error('Must not match a model record.')
+          }, (err) => {
+            expect(err).to.be.defined
+            expect(err).to.be.an.instanceof(PasswordMismatchError)
+            expect(err.name).to.be.equal('PasswordMismatchError')
+            expect(err.message).to.be.equal("Can't find email: 'user@example.org' in some_table.")
+          })
+        })
+      })
+
+      describe('after save', function () {
+        this.timeout(5000)
+        beforeEach(function () {
+          return model.save()
+        })
+
+        it('resolves the Model record if the password matches', function () {
+          return BasicModel.__mkHash('testing').then( (password)=> {
+            expectedQueryResponse = [{
+              id: 1,
+              email: 'user@example.org',
+              password_digest: password
+            }]
+            return BasicModel.login({email: 'user@example.org'}, 'testing').then(
+            (model) => {
+              expect(model).to.be.defined
+              expect(model.get('email')).to.be.equal('user@example.org')
+            }, (err) => {
+              expect(err).to.be.undefined
+            })
+          })
+        })
+
+        it('rejects with a PasswordMismatchError if the password does not match', function () {
+          return BasicModel.__mkHash('testing').then( (password)=> {
+            expectedQueryResponse = [{
+              id: 1,
+              email: 'user@example.org',
+              password_digest: password
+            }]
+            return BasicModel.login({email: 'user@example.org'}, 'invalid').then(
+            (model) => {
+              throw Error('Must not match a model record.')
+            }, (err) => {
+              expect(err).to.be.defined
+              expect(err).to.be.an.instanceof(PasswordMismatchError)
+              expect(err.name).to.equal('PasswordMismatchError')
+              expect(err.message).to.equal('Invalid password')
+            })
+          })
+        })
+
+        it('rejects with a PasswordMismatchError if the no password is provided', function () {
+          return BasicModel.__mkHash('testing').then( (password)=> {
+            expectedQueryResponse = [{
+              id: 1,
+              email: 'user@example.org',
+              password_digest: password
+            }]
+            return BasicModel.login({email: 'user@example.org'}).then(
+            (model) => {
+              throw Error('Must not match a model record.')
+            }, (err) => {
+              expect(err).to.be.defined
+              expect(err).to.be.an.instanceof(PasswordMismatchError)
+              expect(err.name).to.equal('PasswordMismatchError')
+              expect(err.message).to.equal('Invalid password')
+            })
+          })
+        })
+
+      })
+    })
+
+    describe('without hasSecurePassword on this model', function () {
+      it('calls the model`s `login` class method', function () {
+        const Model = bookshelf.Model.extend({})
+        return BasicModel.__mkHash('testing').then( (password)=> {
+          expectedQueryResponse = [{
+            id: 1,
+            email: 'user@example.org',
+            password_digest: password
+          }]
+
+          return Model.login({email: 'user@example.org'}, 'testing').then(
+          (model) => {
+            throw Error('Must not match a model record.')
+          }, (err) => {
+            expect(err).to.be.defined
+            expect(err.message).to.be.equal("It's not a secure password enabled model.")
+          })
+        })
       })
     })
   })

--- a/test/secure-password.spec.js
+++ b/test/secure-password.spec.js
@@ -15,12 +15,14 @@ describe('bookshelf-secure-password', function () {
   let CustomModel
   let expectedQueryResponse
 
+  this.timeout(5000)
+
   before(function () {
     knex = new Knex({ client: 'pg' })
     mockKnex.mock(knex)
     let tracker = mockKnex.getTracker()
     tracker.install()
-    tracker.on('query', (query)=> query.response(expectedQueryResponse) )
+    tracker.on('query', (query) => query.response(expectedQueryResponse))
 
     bookshelf = new Bookshelf(knex)
     bookshelf.plugin(securePassword)
@@ -34,7 +36,6 @@ describe('bookshelf-secure-password', function () {
       tableName: 'other_table',
       hasSecurePassword: 'custom_column'
     })
-
   })
 
   beforeEach(function () {
@@ -231,13 +232,12 @@ describe('bookshelf-secure-password', function () {
       })
 
       describe('after save', function () {
-        this.timeout(5000)
         beforeEach(function () {
           return model.save()
         })
 
         it('resolves the Model record if the password matches', function () {
-          return BasicModel.__mkHash('testing').then( (password)=> {
+          return BasicModel.__mkHash('testing').then((password) => {
             expectedQueryResponse = [{
               id: 1,
               email: 'user@example.org',
@@ -254,7 +254,7 @@ describe('bookshelf-secure-password', function () {
         })
 
         it('rejects with a PasswordMismatchError if the password does not match', function () {
-          return BasicModel.__mkHash('testing').then( (password)=> {
+          return BasicModel.__mkHash('testing').then((password) => {
             expectedQueryResponse = [{
               id: 1,
               email: 'user@example.org',
@@ -273,7 +273,7 @@ describe('bookshelf-secure-password', function () {
         })
 
         it('rejects with a PasswordMismatchError if the no password is provided', function () {
-          return BasicModel.__mkHash('testing').then( (password)=> {
+          return BasicModel.__mkHash('testing').then((password) => {
             expectedQueryResponse = [{
               id: 1,
               email: 'user@example.org',
@@ -290,14 +290,13 @@ describe('bookshelf-secure-password', function () {
             })
           })
         })
-
       })
     })
 
     describe('without hasSecurePassword on this model', function () {
       it('calls the model`s `login` class method', function () {
         const Model = bookshelf.Model.extend({})
-        return BasicModel.__mkHash('testing').then( (password)=> {
+        return BasicModel.__mkHash('testing').then((password) => {
           expectedQueryResponse = [{
             id: 1,
             email: 'user@example.org',


### PR DESCRIPTION
This patch allows to do:
  ```javascript
  User.login({email: 'user@example.org'}, 'testing')
      .then((usr) => console.log(`Auth as ${usr.get('name').}`))
      .catch((err) => console.error(err.message) )
  ```
It is a simple contribution, however may be useful for most usecases.

I name it `login`, through you may prefer to name it `signIn`, if you want this change or some other, please, let me know.