### PR TITLE
upgrade bcrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/venables/bookshelf-secure-password#readme",
   "dependencies": {
-    "bcrypt": "^1.0.2"
+    "bcrypt": "^2.0.0"
   },
   "devDependencies": {
     "bookshelf": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-secure-password",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A Bookshelf.js plugin for handling secure passwords",
   "main": "lib/secure-password.js",
   "scripts": {


### PR DESCRIPTION
hi, [bcrypt has a new release](https://github.com/kelektiv/node.bcrypt.js/blob/master/CHANGELOG.md#200-2018-04-07) which changes the default bcrypt version. It breaks my migrations because I use its latest in my repo but this package still uses the previous version.

I upgraded bcrypt to its latest and run the tests, seems like nothing is broken.

<img width="828" alt="image" src="https://user-images.githubusercontent.com/440086/38635476-44a726ba-3d7a-11e8-866e-467bfad10272.png">

might help others as well.