### PR TITLE
Update to the newer virtuals plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ function signIn (email, password) {
 ## Notes
 
 * BCrypt requires that passwords are 72 characters maximum (it ignores characters after 72).
-* This library enables the built-in `virtuals` plugin on Bookshelf for the virtual `password` field.
+* This library enables the `bookshelf-virtuals-plugin` plugin on Bookshelf for the virtual `password` field.
 * Passing a `null` value to the password will clear the `password_digest`.
 * Passing `undefined` or a zero-length string to the password will leave the `password_digest` as-is
 

--- a/lib/secure-password.js
+++ b/lib/secure-password.js
@@ -18,7 +18,7 @@ function enableSecurePasswordPlugin (Bookshelf) {
   /**
    * Enable the `virtuals` plugin to prevent `password` from leaking
    */
-  Bookshelf.plugin('virtuals')
+  Bookshelf.plugin('bookshelf-virtuals-plugin')
 
   /**
    * Get the password field from the plugin configuration.  defaults to `password_digest`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "mocha": "^6.2.0",
     "mock-knex": "^0.4.6",
     "nyc": "^14.1.1",
-    "standard": "^13.1.0"
+    "standard": "^13.1.0",
+    "bookshelf-virtuals-plugin": "^0.1.1",
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "mock-knex": "^0.4.6",
     "nyc": "^14.1.1",
     "standard": "^13.1.0",
-    "bookshelf-virtuals-plugin": "^0.1.1",
+    "bookshelf-virtuals-plugin": "^0.1.1"
   }
 }


### PR DESCRIPTION
The old lib got deprecated and now throws warnings.
This doesn't affect the functionality and fully tested it in my local project.